### PR TITLE
Support expect_offense template arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,3 +54,7 @@ RSpec/ExampleLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
+
+Style/FormatStringToken:
+  Exclude:
+    - spec/rubocop/**/*.rb

--- a/spec/support/expect_offense.rb
+++ b/spec/support/expect_offense.rb
@@ -4,12 +4,13 @@
 #
 # This mixin is the same as rubocop's ExpectOffense except the default
 # filename ends with `_spec.rb`
+
 module ExpectOffense
   include RuboCop::RSpec::ExpectOffense
 
   DEFAULT_FILENAME = 'example_spec.rb'
 
-  def expect_offense(source, filename = DEFAULT_FILENAME)
+  def expect_offense(source, filename = DEFAULT_FILENAME, *args, **kwargs)
     super
   end
 


### PR DESCRIPTION
Pass keyword arguments through to `RuboCop::RSpec::ExpectOffense#expect_offense`. These are used to set template replacements like `%{name}`.

Allow code offense templates in specs to use `%{name}`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `default/config.yml` to the next major version.